### PR TITLE
fix unshifted text color

### DIFF
--- a/ShiftColorName/ShiftColorNamePlugin.cs
+++ b/ShiftColorName/ShiftColorNamePlugin.cs
@@ -81,7 +81,7 @@ namespace eradev.monstersanctuary.ShiftColorName
 
                 menuItem.TextColorOverride = monster.Shift switch
                 {
-                    EShift.Normal => menuItem.TextColorOverride,
+                    EShift.Normal => Color.gray,
                     EShift.Light => GameDefines.ColorLightShift,
                     EShift.Dark => GameDefines.ColorDarkShift,
                     _ => throw new ArgumentOutOfRangeException()


### PR DESCRIPTION
Without this the text names of my unhifted monsters were showing up as dark shifted, even though you could see that the monster image was in fact unshifted.

The way I triggered it was to simply hatch an unshifted egg when I already had shifted variants. Then just go into the monster army donation screen and see if the unshifted monster text is correctly colored.