### PR TITLE
fix randomizer for blob blurg & essential items

### DIFF
--- a/RandomRandomizer/RandomRandomizerPlugin.cs
+++ b/RandomRandomizer/RandomRandomizerPlugin.cs
@@ -336,6 +336,21 @@ namespace eradev.monstersanctuary.RandomRandomizer
                 _log.LogDebug($"Chest ID: {__instance.ID}");
                 _log.LogDebug($"Chest name: {__instance.name}");
 
+                if (__instance.Item != null)
+                {
+                    _log.LogDebug($"Chest item name: {__instance.Item.GetComponent<BaseItem>().GetName()}");
+                }
+                else if (__instance.Gold == 0)
+                {
+                    _log.LogDebug("ChestRandomizer ignore: Item is null and has no gold");
+
+                    return;
+                }
+                else
+                {
+                    _log.LogDebug($"Chest gold: {__instance.Gold}");
+                }
+
                 if (!_isEnabled.Value || !_randomizeChestsEnabled.Value)
                 {
                     _log.LogDebug("ChestRandomizer ignore: Disabled in config");


### PR DESCRIPTION
Fixes #3, #4, #5 and #6.

Did a full playthrough checking each essential chest.

Initially I thought I was going to need to do something with the current scene name for blob burg. So I played through it checking each chest with this:
```
if (PlayerController.Instance.Minimap.CurrentEntry.MapArea.Name == "Blob Burg")
{
    _log.LogDebug($"Current scene: {PlayerController.Instance.Minimap.CurrentEntry.MapData.SceneName}");
}
```
But it turns out the only fix necessary for everything was the one included in this pull request. If the chest item is null and the chest has no gold, it is an essential item that should not be randomized.